### PR TITLE
MADE THE FOLLOWING CHANGES:  Spark 3.5 added a leading Connection par…

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        profile: ['spark34']
+        profile: ['spark35']
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
…ameter to JdbcUtils.getSchema GitHub and rewrote JdbcUtils.schemaString so the first parameter is now the JdbcDialect GitHub.

The connector still calls the Spark 3.4 variants (see original lines) GitHub, so recompiling without these edits fails – and running the old jar explodes with NoSuchMethodError